### PR TITLE
fix(temporal): server Service must not select UI pods

### DIFF
--- a/deploy/helm/temporal/templates/deployment.yaml
+++ b/deploy/helm/temporal/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       labels:
         {{- include "temporal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/temporal/templates/service.yaml
+++ b/deploy/helm/temporal/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
       name: http
   selector:
     {{- include "temporal.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server


### PR DESCRIPTION
Problem
- The Temporal server Service selector matches both server and UI pods because both share the same `app.kubernetes.io/name` and `app.kubernetes.io/instance` labels.
- This can route port 7233 traffic to the UI container (8080), breaking gRPC and causing intermittent failures.

Fix
- Label server pods with `app.kubernetes.io/component=server`.
- Add `app.kubernetes.io/component=server` to the server Service selector.

## Validation Evidence
- `helm lint deploy/helm/temporal` passes.
- Rendered `Service/temporal-prod` selector includes `app.kubernetes.io/component: server`.

## Rollback Plan
- Revert this PR; Service selector will return to previous behavior.