### PR TITLE
fix(helm): set runAsNonRoot on UI deployment for Kyverno compliance

### DIFF
--- a/deploy/helm/temporal/templates/ui-deployment.yaml
+++ b/deploy/helm/temporal/templates/ui-deployment.yaml
@@ -23,7 +23,9 @@ spec:
         app.kubernetes.io/component: ui
     spec:
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
       serviceAccountName: {{ include "temporal.serviceAccountName" . }}
       {{- with .Values.ui.extraInitContainers }}
       initContainers:


### PR DESCRIPTION
## Summary

- Fixes Kyverno `require-non-root-security-context` policy violation that blocks the temporal UI deployment on rke2-nonprod
- Changes `runAsNonRoot: false` to `runAsNonRoot: true` with `runAsUser: 1000`
- The `temporalio/ui` image supports running as non-root

## Context

After temporal namespace separation (#658 in bbi-infrastructure), ArgoCD sync fails for both `temporal-dev` and `temporal-staging` because the UI deployment is rejected by Kyverno admission webhook.

## Test plan

- [ ] ArgoCD syncs temporal-dev and temporal-staging successfully
- [ ] Temporal UI pod starts and serves the web interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)