### PR TITLE
docs(auth): add canonical ownership matrix link

### DIFF
--- a/docs/auth/AUTH_INTEGRATION_CONTRACT.md
+++ b/docs/auth/AUTH_INTEGRATION_CONTRACT.md
@@ -1,0 +1,65 @@
+# Auth Integration Contract: temporal
+
+## Ownership
+
+1. Environment and deployment source of truth lives in: `k8s/bbi-infrastructure`
+2. Canonical ownership matrix reference: `docs/AUTH_OWNERSHIP_MATRIX.md` (in `k8s/bbi-infrastructure`)
+3. This repo owns service/chart capability only.
+4. This repo does not own production environment auth values unless explicitly documented.
+
+## Canonical Domains
+
+- Authentik (prod): `https://auth0.mereka.io`
+- Authentik (staging): `https://staging.auth0.mereka.io`
+- Authentik (dev): `https://auth0.mereka.dev`
+- Legacy reserved domain: `auth.mereka.io` (MUST NOT be used for new or active config)
+
+## Service Auth Pattern
+
+- Service: `temporal`
+- Pattern: `native-oidc`
+- Domain(s): `temporal.mereka.io,temporal.mereka.dev`
+
+## Required Runtime Configuration
+
+- Required env vars:
+  - `TODO_ENV_VAR_1`
+  - `TODO_ENV_VAR_2`
+- Secret source:
+  - Infisical path: `/k8s/temporal`
+  - ESO target secret: `temporal-secrets`
+
+## Ingress Contract (Forward Auth Only)
+
+If pattern is `forward-auth`, ingress MUST include:
+
+```yaml
+nginx.ingress.kubernetes.io/auth-url: "https://auth0.mereka.io/outpost.goauthentik.io/auth/nginx"
+nginx.ingress.kubernetes.io/auth-signin: "https://auth0.mereka.io/outpost.goauthentik.io/start?rd=$scheme://$host$escaped_request_uri"
+nginx.ingress.kubernetes.io/auth-response-headers: "Set-Cookie,X-authentik-username,X-authentik-groups,X-authentik-email,X-authentik-name,X-authentik-uid"
+```
+
+## OIDC Contract (Native OIDC / App-level OIDC)
+
+If pattern uses OIDC:
+
+- Issuer URL MUST be canonical Authentik URL
+- Issuer/discovery path must be provider-specific (`/application/o/<slug>/`)
+- Client secret MUST come from secret manager (not plaintext values files)
+
+## Verification
+
+- Local:
+  - `TODO_LOCAL_CHECK_1`
+  - `TODO_LOCAL_CHECK_2`
+- Platform:
+  - `auth-verify contract-check --format json`
+  - `auth-verify drift-detect --format json`
+
+## Change Management
+
+- Any auth pattern/domain change requires:
+  - Update in canonical infra repo
+  - Update in auth registry/spec if needed
+  - Evidence attached in PR
+


### PR DESCRIPTION
## Summary
- update auth integration contract ownership section
- add explicit link to canonical `docs/AUTH_OWNERSHIP_MATRIX.md` in `k8s/bbi-infrastructure`
- keep this repo as capability-only, non-authoritative for env auth values

## Evidence
- Source tracker: https://github.com/Biji-Biji-Initiative/authentik-config/blob/main/AUTHENTIK_CROSS_REPO_SYNC_TRACKER.md
- Rollout state: https://github.com/Biji-Biji-Initiative/authentik-config/blob/main/reports/auth_ownership_link_rollout_state_2026-03-04.md
- Audit TSV: https://github.com/Biji-Biji-Initiative/authentik-config/blob/main/reports/auth_ownership_link_audit_2026-03-04.tsv

## Scope
- docs-only change
- no runtime configuration changes
