### PR TITLE
fix(chart): wire Bitnami PG auth.existingSecret (postgres-password key)

### DIFF
--- a/deploy/helm/temporal/templates/externalsecret.yaml
+++ b/deploy/helm/temporal/templates/externalsecret.yaml
@@ -17,6 +17,15 @@ spec:
     - secretKey: password
       remoteRef:
         key: {{ required "externalSecret.keys.dbPassword is required when externalSecret.enabled=true" .Values.externalSecret.keys.dbPassword | quote }}
+    {{- if .Values.externalSecret.keys.dbPostgresPassword }}
+    # Bitnami PostgreSQL admin (superuser "postgres") password. Required when
+    # wiring postgresql.auth.existingSecret so the subchart initialises the
+    # superuser deterministically on fresh PVCs instead of generating a random
+    # password that drifts from what the app expects.
+    - secretKey: postgres-password
+      remoteRef:
+        key: {{ .Values.externalSecret.keys.dbPostgresPassword | quote }}
+    {{- end }}
 {{- if and .Values.ui.enabled .Values.ui.oidc.enabled }}
 ---
 apiVersion: external-secrets.io/v1

--- a/deploy/helm/temporal/values.yaml
+++ b/deploy/helm/temporal/values.yaml
@@ -154,6 +154,10 @@ externalSecret:
   keys:
     dbPassword: ""
     uiClientSecret: ""
+    # Optional: Infisical key for the PostgreSQL superuser ("postgres") password.
+    # Required when wiring postgresql.auth.existingSecret so the Bitnami subchart
+    # can deterministically initialise the superuser on fresh PVCs.
+    dbPostgresPassword: ""
 
 # Horizontal Pod Autoscaling
 autoscaling:


### PR DESCRIPTION
## Summary

- Add optional `externalSecret.keys.dbPostgresPassword` value on the temporal chart.
- When set, the `temporal-db` ExternalSecret emits a second key `postgres-password` sourced from the configured Infisical path.
- Unblocks wiring `postgresql.auth.existingSecret` in the Bitnami PostgreSQL subchart so the superuser password is deterministic on fresh PVCs.

## Why

Reference: Biji-Biji-Initiative/bbi-infrastructure#3013

On 2026-04-16 the temporal-staging PVC was recreated and the Bitnami subchart initialised postgres with its own generated password (`changeme` from chart defaults), which drifted from the app-side password managed by ESO (`temporal-staging-changeme`). Result: Temporal server failed to authenticate against its own DB on the fresh PVC.

Other Bitnami PG apps in the platform (authentik, calcom, n8n, listmonk, etc.) avoid this by wiring `postgresql.auth.existingSecret` — pointing the subchart at a Kubernetes secret that ESO owns, so both the app and the subchart read the same value. Temporal couldn't follow that pattern because its chart ExternalSecret only emitted a single `password` key. This PR adds the second key Bitnami needs (`postgres-password`).

## Backward compatibility

Fully backward compatible. When `externalSecret.keys.dbPostgresPassword` is unset or empty, the rendered ExternalSecret emits only the `password` key, matching existing behaviour.

## Follow-up

- [ ] Biji-Biji-Initiative/bbi-infrastructure PR wires `dbPostgresPassword` in dev/staging overlays and adds `postgresql.auth.existingSecret` + `secretKeys`.