### PR TITLE
feat(chart): support optional Temporal UI image digest

### DIFF
--- a/deploy/helm/temporal/templates/ui-deployment.yaml
+++ b/deploy/helm/temporal/templates/ui-deployment.yaml
@@ -34,7 +34,11 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
+          {{- if .Values.ui.image.digest }}
+          image: "{{ .Values.ui.image.repository }}@{{ .Values.ui.image.digest }}"
+          {{- else }}
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/temporal/values.yaml
+++ b/deploy/helm/temporal/values.yaml
@@ -124,6 +124,7 @@ ui:
   image:
     repository: temporalio/ui
     tag: "2.31.2"
+    digest: ""
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Summary

Adds backward-compatible `ui.image.digest` support to the Temporal Helm chart.

When `ui.image.digest` is set, the UI Deployment renders `repository@digest`; otherwise it keeps the existing `repository:tag` behavior.

## Validation

- `helm lint deploy/helm/temporal` PASS
- Cross-repo BBI render with prod values PASS: `temporalio/ui@sha256:7be8d6e41d4846ccb718c4f35956c9557512f8085e94a73954286a4e95113703`
- No Go module or Go source files exist in this checkout, so `go test ./...` and `golangci-lint run` are not applicable to this chart-only repo state.

## Rollout

Merge before Biji-Biji-Initiative/bbi-infrastructure `codex/7534-temporal-ui-policy-20260622` so the BBI-side digest value is realized by ArgoCD render.

No runtime, Argo, secret, DNS, DB, backup, CI rerun, or build dispatch was performed.
